### PR TITLE
fix: correct validation rules syntax

### DIFF
--- a/app/Http/Requests/CategoryRequest.php
+++ b/app/Http/Requests/CategoryRequest.php
@@ -22,7 +22,7 @@ class CategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'category_description' => 'required' |'string' | 'max:50',
+            'category_description' => 'required | string | max:50',
             'type_id' => 'required'
         ];
     }

--- a/app/Http/Requests/StoreTransactionRequest.php
+++ b/app/Http/Requests/StoreTransactionRequest.php
@@ -22,15 +22,15 @@ class StoreTransactionRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'transaction_description' => 'required' | 'string' | 'max:50',
+            'transaction_description' => 'required | string | max:50',
             'category_id' => 'required',
-            'category_description' => 'required_if:category_id,0' | 'string' | 'max:50',
-            'date' => 'required' | 'date',
-            'type_id' => 'required' | 'min:1' | 'max:2',
-            'transaction_value' => 'required' | 'decimal:0,2' | 'min:1',
-            'payment_method_id' => 'required_if:type_id,2' | 'prohibited_if:type_id,1',
-            'installments' => 'required_if:payment_method_id,4' | 'prohibited_unless:payment_method_id,4' | 'min:1',
-            'card_id' => 'required_if:payment_method_id,4' | 'prohibited_unless:payment_method_id,4',
+            'category_description' => 'required_if:category_id,0 | string | max:50',
+            'date' => 'required | date',
+            'type_id' => 'required | min:1 | max:2',
+            'transaction_value' => 'required | decimal:0,2 | min:1',
+            'payment_method_id' => 'required_if:type_id,2 | prohibited_if:type_id,1',
+            'installments' => 'required_if:payment_method_id,4 | prohibited_unless:payment_method_id,4 | min:1',
+            'card_id' => 'required_if:payment_method_id,4 | prohibited_unless:payment_method_id,4',
         ];
     }
 }

--- a/app/Http/Requests/UpdateTransactionRequest.php
+++ b/app/Http/Requests/UpdateTransactionRequest.php
@@ -22,10 +22,10 @@ class UpdateTransactionRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'transaction_description' => 'string' | 'max:50',
+            'transaction_description' => 'string | max:50',
             'date' => 'date',
-            'transaction_value' => 'decimal:0,2' | 'min:1',
-            'payment_method_id' => 'min:1' | 'max:4',
+            'transaction_value' => 'decimal:0,2 | min:1',
+            'payment_method_id' => 'min:1 | max:4',
             'installments' => 'min:1'
         ];
     }


### PR DESCRIPTION
correct validation rules syntax for category and transaction requests